### PR TITLE
Allow custom chrome executable locations

### DIFF
--- a/src/Blt/Plugin/Commands/Pa11yTestCommand.php
+++ b/src/Blt/Plugin/Commands/Pa11yTestCommand.php
@@ -151,6 +151,7 @@ class Pa11yTestCommand extends TestsCommandBase
         'hideElements' => $pa11y_config->get('config.hideElements', ['svg']),
         'ignore' => $pa11y_config->get('config.ignore', ['notice']),
         'chromeLaunchConfig' => [
+          'executablePath' => $pa11y_config->get('config.executablePath', '/usr/bin/chromium-browser'),
           'ignoreHTTPSErrors' => TRUE,
           'args' => [
             '--no-sandbox',


### PR DESCRIPTION
Debian based installs use chromium rather than chromium-browser

This allows you to specify config.executablePath and override based upon your local environment